### PR TITLE
Replace roll-your-own C basic types with standard ones

### DIFF
--- a/src/sys_null/include/kcb5.h
+++ b/src/sys_null/include/kcb5.h
@@ -1,15 +1,6 @@
 
-typedef unsigned char uint8_t;
-typedef char int8_t;
-typedef short int16_t;
-typedef int int32_t;
-typedef unsigned int uint32_t;
-
-typedef enum
-{
-	false = 0,
-	true = 1
-} bool;
+#include <stdint.h>
+#include <stdbool.h>
 
 // not defined in SDK:
 #define M_PI	(3.14159265358979323846f)


### PR DESCRIPTION
Provided by stdbool.h and stdint.h